### PR TITLE
Fix issues after separating out the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: "nightly"
           components: "clippy"
 
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           components: "miri"
 
       - name: Run tests
-        run: MIRIFLAGS='-Zmiri-tree-borrows' cargo miri test --package java_string --workspace --all-features
+        run: MIRIFLAGS='-Zmiri-tree-borrows' cargo miri test --package java_string --all-features
 
   typos:
     name: Typos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: cargo test --workspace --no-default-features --all-targets
 
   miri:
-    name: Miri Tests
+    name: Miri Tests on Java String
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
@@ -84,7 +84,7 @@ jobs:
           components: "miri"
 
       - name: Run tests
-        run: MIRIFLAGS='-Zmiri-tree-borrows' cargo miri test --workspace --all-features --all-targets
+        run: MIRIFLAGS='-Zmiri-tree-borrows' cargo miri test --package java_string --workspace --all-features
 
   typos:
     name: Typos

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea/

--- a/java_string/src/owned.rs
+++ b/java_string/src/owned.rs
@@ -23,6 +23,7 @@ pub struct JavaString {
     vec: Vec<u8>,
 }
 
+#[allow(clippy::multiple_inherent_impl)]
 impl JavaString {
     #[inline]
     #[must_use]
@@ -121,9 +122,8 @@ impl JavaString {
                         Ok(()) => {
                             unsafe {
                                 // SAFETY: validation succeeded
-                                result
-                                    .push_java_str(JavaStr::from_semi_utf8_unchecked(&v[index..]));
-                            }
+                                result.push_java_str(JavaStr::from_semi_utf8_unchecked(&v[index..]))
+                            };
                             return Cow::Owned(result);
                         }
                         Err(error) => {
@@ -131,8 +131,8 @@ impl JavaString {
                                 // SAFETY: validation succeeded up to this index
                                 result.push_java_str(JavaStr::from_semi_utf8_unchecked(
                                     v.get_unchecked(index..index + error.valid_up_to),
-                                ));
-                            }
+                                ))
+                            };
                             result.push_str(REPLACEMENT);
                             index += error.valid_up_to + error.error_len.unwrap_or(1) as usize;
                         }
@@ -326,9 +326,7 @@ impl JavaString {
     pub fn pop(&mut self) -> Option<JavaCodePoint> {
         let ch = self.chars().next_back()?;
         let newlen = self.len() - ch.len_utf8();
-        unsafe {
-            self.vec.set_len(newlen);
-        }
+        unsafe { self.vec.set_len(newlen) };
         Some(ch)
     }
 
@@ -369,8 +367,8 @@ impl JavaString {
                 self.vec.as_mut_ptr().add(idx),
                 len - next,
             );
-            self.vec.set_len(len - (next - idx));
-        }
+            self.vec.set_len(len - (next - idx))
+        };
         ch
     }
 

--- a/java_string/src/slice.rs
+++ b/java_string/src/slice.rs
@@ -29,6 +29,7 @@ pub struct JavaStr {
     inner: [u8],
 }
 
+#[allow(clippy::multiple_inherent_impl)]
 impl JavaStr {
     /// Converts `v` to a `&JavaStr` if it is fully-valid UTF-8, i.e. UTF-8
     /// without surrogate code points. See [`std::str::from_utf8`].
@@ -1746,8 +1747,8 @@ impl Debug for JavaStr {
             if esc.len() != 1 || c.as_char().is_none() {
                 unsafe {
                     // SAFETY: any invalid UTF-8 should have been caught by a previous iteration
-                    f.write_str(self[from..i].as_str_unchecked())?;
-                }
+                    f.write_str(self[from..i].as_str_unchecked())?
+                };
                 for c in esc {
                     f.write_char(c)?;
                 }
@@ -1756,8 +1757,8 @@ impl Debug for JavaStr {
         }
         unsafe {
             // SAFETY: any invalid UTF-8 should have been caught by the loop above
-            f.write_str(self[from..].as_str_unchecked())?;
-        }
+            f.write_str(self[from..].as_str_unchecked())?
+        };
         f.write_char('"')
     }
 }

--- a/valence_nbt/Cargo.toml
+++ b/valence_nbt/Cargo.toml
@@ -14,6 +14,7 @@ java_string = ["dep:java_string"]
 snbt = []
 preserve_order = ["dep:indexmap"]
 serde = ["dep:serde", "dep:thiserror", "indexmap?/serde"]
+valence_ident = ["dep:valence_ident"]
 
 [dependencies]
 byteorder = { version = "1.5.0", optional = true }
@@ -23,6 +24,7 @@ java_string = { version = "0.1.2", path = "../java_string", optional = true }
 serde = { version = "1.0.200", features = ["derive"], optional = true }
 thiserror = { version = "1.0.59", optional = true }
 uuid = { version = "1.8.0", optional = true }
+valence_ident = { version = "0.2.0-alpha.1", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/valence_nbt/src/binary/decode.rs
+++ b/valence_nbt/src/binary/decode.rs
@@ -12,8 +12,9 @@ use crate::{Compound, Error, List, Result, Value};
 /// string). If the root value is of type [`Tag::End`], then `None` is returned.
 /// If the data is malformed or the reader returns an error, then an error is
 /// returned.
-pub fn from_binary<'a, S>(reader: impl ReadBytes<'a>) -> Result<Option<(S, Value<S>)>>
+pub fn from_binary<'a, R, S>(reader: R) -> Result<Option<(S, Value<S>)>>
 where
+    R: ReadBytes<'a>,
     S: FromModifiedUtf8<'a> + Hash + Ord,
 {
     let mut state = DecodeState { reader, depth: 0 };

--- a/valence_nbt/src/binary/encode.rs
+++ b/valence_nbt/src/binary/encode.rs
@@ -11,12 +11,11 @@ use crate::value::ValueRef;
 use crate::{Compound, Error, List, Result};
 
 /// Encode binary NBT data to the given writer.
-pub fn to_binary<'a, S>(
-    writer: impl Write,
-    root_name: &(impl ToModifiedUtf8 + ?Sized),
-    value: impl Into<ValueRef<'a, S>>,
-) -> Result<()>
+pub fn to_binary<'a, W, R, V, S>(writer: W, root_name: &R, value: V) -> Result<()>
 where
+    W: Write,
+    R: ToModifiedUtf8 + ?Sized,
+    V: Into<ValueRef<'a, S>>,
     S: ToModifiedUtf8 + Hash + Ord + 'a,
 {
     let value = value.into();

--- a/valence_nbt/src/binary/tests.rs
+++ b/valence_nbt/src/binary/tests.rs
@@ -22,7 +22,7 @@ fn round_trip() {
 #[test]
 fn check_min_sizes() {
     fn check(min_val: Value, expected_size: usize) {
-        /// TAG_Compound + root name + field tag + field name + TAG_End
+        /// `TAG_Compound` + root name + field tag + field name + `TAG_End`
         const COMPOUND_OVERHEAD: usize = 1 + 2 + 1 + 2 + 1;
 
         let dbg = format!("{min_val:?}");
@@ -44,7 +44,7 @@ fn check_min_sizes() {
     check(Value::Float(0.0), 4);
     check(Value::Double(0.0), 8);
     check(Value::ByteArray([].into()), 4);
-    check(Value::String("".into()), 2);
+    check(Value::String(String::new()), 2);
     check(Value::List(Vec::<i32>::new().into()), 5);
     check(Value::Compound(compound!()), 1);
     check(Value::IntArray([].into()), 4);

--- a/valence_nbt/src/binary/tests.rs
+++ b/valence_nbt/src/binary/tests.rs
@@ -65,7 +65,7 @@ fn deeply_nested_compound_decode() {
     buf.push(Tag::End as u8); // End root compound
 
     // Should not overflow the stack
-    let _ = from_binary::<String>(&mut buf.as_slice());
+    let _ = from_binary::<_, String>(&mut buf.as_slice());
 }
 
 #[test]
@@ -84,7 +84,7 @@ fn deeply_nested_list_decode() {
     buf.push(Tag::End as u8); // End root compound
 
     // Should not overflow the stack
-    let _ = from_binary::<String>(&mut buf.as_slice());
+    let _ = from_binary::<_, String>(&mut buf.as_slice());
 }
 
 fn example_compound() -> Compound {

--- a/valence_nbt/src/serde/ser.rs
+++ b/valence_nbt/src/serde/ser.rs
@@ -148,9 +148,9 @@ impl Serializer for CompoundSerializer {
         unsupported!("none")
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unsupported!("some")
     }
@@ -172,18 +172,18 @@ impl Serializer for CompoundSerializer {
         unsupported!("unit variant")
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unsupported!("newtype struct")
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -191,7 +191,7 @@ impl Serializer for CompoundSerializer {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unsupported!("newtype variant")
     }
@@ -327,9 +327,9 @@ impl Serializer for ValueSerializer {
         unsupported!("none")
     }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(self)
     }
@@ -351,18 +351,18 @@ impl Serializer for ValueSerializer {
         Ok(Value::String(variant.into()))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -370,7 +370,7 @@ impl Serializer for ValueSerializer {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unsupported!("newtype variant")
     }
@@ -447,9 +447,9 @@ impl SerializeSeq for ValueSerializeSeq {
 
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         macro_rules! serialize_variant {
             ($variant:ident, $vec:ident, $elem:ident) => {{
@@ -553,9 +553,9 @@ where
 
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         debug_assert!(
             self.key.is_none(),
@@ -571,9 +571,9 @@ where
         }
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         let key = self
             .key
@@ -612,13 +612,9 @@ where
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.c.insert(key, value.serialize(ValueSerializer)?);
         Ok(())


### PR DESCRIPTION
- Fixes clippy issues.
   - Use stable clippy in CI, to avoid random unrelated failures on pushes.
- Change miri test in CI on only the Java String crate.
   - This crate was the reason we add miri in the first place, only running it on this crate should speed up the CI tests.
   - The deeply nested NBT test was failing due to a stack overflow in rustc.
   - For some reason `--all-targets` makes it exclude doctests, so removed that flag.
- Added RustRover files to the gitignore.